### PR TITLE
chore: extend eventbus events type to support primitives

### DIFF
--- a/lib/Event.ts
+++ b/lib/Event.ts
@@ -1,1 +1,1 @@
-export interface Event { }
+export type Event = object | number | string | boolean | null | undefined

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,6 @@
 import { EventBus } from "./EventBus"
+import { EventHandler } from "./EventHandler";
+import { Event } from "./Event";
 import { ProxyBus } from "./ProxyBus"
 import { SimpleBus } from "./SimpleBus"
 
@@ -52,7 +54,7 @@ function getBus(): EventBus {
  * @param name name of the event
  * @param handler callback invoked for every matching event emitted on the bus
  */
-export function subscribe(name: string, handler: (string) => void): void {
+export function subscribe(name: string, handler: EventHandler): void {
     getBus().subscribe(name, handler)
 }
 
@@ -64,7 +66,7 @@ export function subscribe(name: string, handler: (string) => void): void {
  * @param name name of the event
  * @param handler callback passed to `subscribed`
  */
-export function unsubscribe(name: string, handler: (string) => void): void {
+export function unsubscribe(name: string, handler: EventHandler): void {
     getBus().unsubscribe(name, handler)
 }
 
@@ -74,6 +76,6 @@ export function unsubscribe(name: string, handler: (string) => void): void {
  * @param name name of the event
  * @param event event payload
  */
-export function emit(name: string, event: object): void {
+export function emit(name: string, event: Event): void {
     getBus().emit(name, event)
 }


### PR DESCRIPTION
Allows to emit events with some primitives apart from object, such as `number | string | boolean | null | undefined`

To avoid workarounds like https://github.com/nextcloud/spreed/commit/5495e2bdf526f8f18cce7cebf02850baf0ba4d50