### PR TITLE
chore: Prepare 3.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v3.3.0](https://github.com/nextcloud-libraries/nextcloud-event-bus/tree/v3.3.0) \(2024-05-07\)
+
+### Added
+
+-   feat: Allow to fully type events by extending the `NextcloudEvents` interface [\#755](https://github.com/nextcloud-libraries/nextcloud-event-bus/pull/755) \([susnux](https://github.com/susnux)\)
+
+### Fixed
+
+-   fix(readme): update engine requirements according to package.json [\#754](https://github.com/nextcloud-libraries/nextcloud-event-bus/pull/754) \([AaronActu](https://github.com/AaronActu)\)
+-   fix(docs): Adjust invalid example for typed events [\#763](https://github.com/nextcloud-libraries/nextcloud-event-bus/pull/763) ([susnux](https://github.com/susnux)\)
+
+### Changed
+
+-   feat: Add ESLint for linting and prettier for formatting [\#759](https://github.com/nextcloud-libraries/nextcloud-event-bus/pull/759) ([susnux](https://github.com/susnux)\)
+-   feat: Migrate to vite for building and vitest for testing [\#758](https://github.com/nextcloud-libraries/nextcloud-event-bus/pull/758) ([susnux](https://github.com/susnux)\)
+
 ## [v3.2.0](https://github.com/nextcloud/nextcloud-event-bus/tree/v3.2.0) (2024-04-21)
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/event-bus",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/event-bus",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@types/node": "^20.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/event-bus",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "A simple event bus to communicate between Nextcloud components.",
   "keywords": [
     "nextcloud"


### PR DESCRIPTION
## [v3.3.0](https://github.com/nextcloud-libraries/nextcloud-event-bus/tree/v3.3.0) \(2024-05-07\)

### Added

-   feat: Allow to fully type events by extending the `NextcloudEvents` interface [\#755](https://github.com/nextcloud-libraries/nextcloud-event-bus/pull/755) \([susnux](https://github.com/susnux)\)

### Fixed

-   fix(readme): update engine requirements according to package.json [\#754](https://github.com/nextcloud-libraries/nextcloud-event-bus/pull/754) \([AaronActu](https://github.com/AaronActu)\)
-   fix(docs): Adjust invalid example for typed events [\#763](https://github.com/nextcloud-libraries/nextcloud-event-bus/pull/763) ([susnux](https://github.com/susnux)\)

### Changed

-   feat: Add ESLint for linting and prettier for formatting [\#759](https://github.com/nextcloud-libraries/nextcloud-event-bus/pull/759) ([susnux](https://github.com/susnux)\)
-   feat: Migrate to vite for building and vitest for testing [\#758](https://github.com/nextcloud-libraries/nextcloud-event-bus/pull/758) ([susnux](https://github.com/susnux)\)