### PR TITLE
chore: Prepare 3.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v3.3.1](https://github.com/nextcloud-libraries/nextcloud-event-bus/tree/v3.3.1) \(2024-05-28\)
+
+### Fixed
+
+-   fix: Do not include declarations for private globals in distribution [\#772](https://github.com/nextcloud-libraries/nextcloud-event-bus/pull/772) ([susnux](https://github.com/susnux)\)
+
+### Changed
+
+-   chore: Add license information to files and add REUSE workflow [\#773](https://github.com/nextcloud-libraries/nextcloud-event-bus/pull/773) ([susnux](https://github.com/susnux)\)
+
 ## [v3.3.0](https://github.com/nextcloud-libraries/nextcloud-event-bus/tree/v3.3.0) \(2024-05-07\)
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/event-bus",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/event-bus",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@types/node": "^20.12.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/event-bus",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "A simple event bus to communicate between Nextcloud components.",
   "keywords": [
     "nextcloud"


### PR DESCRIPTION
## [v3.3.1](https://github.com/nextcloud-libraries/nextcloud-event-bus/tree/v3.3.1) \(2024-05-28\)

### Fixed

-   fix: Do not include declarations for private globals in distribution [\#772](https://github.com/nextcloud-libraries/nextcloud-event-bus/pull/772) ([susnux](https://github.com/susnux)\)

### Changed

-   chore: Add license information to files and add REUSE workflow [\#773](https://github.com/nextcloud-libraries/nextcloud-event-bus/pull/773) ([susnux](https://github.com/susnux)\)

