### PR TITLE
fix: Allow events without parameters

### DIFF
--- a/lib/EventBus.ts
+++ b/lib/EventBus.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 import type { GenericEvents, NextcloudEvents } from './Event'
+import type { IsUndefined } from './types.ts'
 import { EventHandler } from './EventHandler'
 
 export interface EventBus<E extends GenericEvents = NextcloudEvents> {
@@ -37,5 +38,8 @@ export interface EventBus<E extends GenericEvents = NextcloudEvents> {
 	 * @param name Name of the event to emit
 	 * @param event Event payload to emit
 	 */
-	emit<EventName extends keyof E>(name: EventName, event: E[EventName]): void
+	emit<EventName extends keyof E>(
+		name: EventName,
+		...event: IsUndefined<E[EventName]> extends true ? [] : [E[EventName]]
+	): void
 }

--- a/lib/ProxyBus.ts
+++ b/lib/ProxyBus.ts
@@ -7,8 +7,9 @@ import valid from 'semver/functions/valid.js'
 import major from 'semver/functions/major.js'
 
 import type { GenericEvents, NextcloudEvents } from './Event.js'
-import { EventBus } from './EventBus.js'
-import { EventHandler } from './EventHandler.js'
+import type { EventBus } from './EventBus.js'
+import type { EventHandler } from './EventHandler.js'
+import type { IsUndefined } from './types.ts'
 
 export class ProxyBus<E extends GenericEvents = NextcloudEvents>
 	implements EventBus<E>
@@ -48,7 +49,10 @@ export class ProxyBus<E extends GenericEvents = NextcloudEvents>
 		this.bus.unsubscribe(name, handler)
 	}
 
-	emit<EventName extends keyof E>(name: EventName, event: E[EventName]): void {
-		this.bus.emit(name, event)
+	emit<EventName extends keyof E>(
+		name: EventName,
+		...event: IsUndefined<E[EventName]> extends true ? [] : [E[EventName]]
+	): void {
+		this.bus.emit(name, ...event)
 	}
 }

--- a/lib/SimpleBus.ts
+++ b/lib/SimpleBus.ts
@@ -2,9 +2,10 @@
  * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
-import { GenericEvents, NextcloudEvents } from './Event.js'
-import { EventBus } from './EventBus.js'
-import { EventHandler } from './EventHandler.js'
+import type { GenericEvents, NextcloudEvents } from './Event.js'
+import type { EventBus } from './EventBus.js'
+import type { EventHandler } from './EventHandler.js'
+import type { IsUndefined } from './types.ts'
 
 export class SimpleBus<E extends GenericEvents = NextcloudEvents>
 	implements EventBus<E>
@@ -37,10 +38,14 @@ export class SimpleBus<E extends GenericEvents = NextcloudEvents>
 		)
 	}
 
-	emit<EventName extends keyof E>(name: EventName, event: E[EventName]): void {
-		;(this.handlers.get(name) || []).forEach((h) => {
+	emit<EventName extends keyof E>(
+		name: EventName,
+		...event: IsUndefined<E[EventName]> extends true ? [] : [E[EventName]]
+	): void {
+		const handlers = this.handlers.get(name) || []
+		handlers.forEach((h) => {
 			try {
-				h(event)
+				;(h as EventHandler<(typeof event)[0]>)(event[0])
 			} catch (e) {
 				console.error('could not invoke event listener', e)
 			}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,9 +2,11 @@
  * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
-import { EventBus } from './EventBus'
-import { EventHandler } from './EventHandler'
-import { NextcloudEvents } from './Event'
+import type { EventBus } from './EventBus'
+import type { EventHandler } from './EventHandler'
+import type { NextcloudEvents } from './Event'
+import type { IsUndefined } from './types.ts'
+
 import { ProxyBus } from './ProxyBus'
 import { SimpleBus } from './SimpleBus'
 
@@ -91,7 +93,9 @@ export function unsubscribe<K extends keyof NextcloudEvents>(
  */
 export function emit<K extends keyof NextcloudEvents>(
 	name: K,
-	event: NextcloudEvents[K],
+	...event: IsUndefined<NextcloudEvents[K]> extends true
+		? []
+		: [NextcloudEvents[K]]
 ): void {
-	getBus().emit(name, event)
+	getBus().emit(name, ...event)
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,8 +2,8 @@
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
-import type { Event } from './Event'
 
-export interface EventHandler<T extends Event> {
-	(event: T): void
-}
+/**
+ * Helper to check if a type is undefined
+ */
+export type IsUndefined<T> = [T] extends [undefined] ? true : false


### PR DESCRIPTION
Currently `emit` requires two parameters even if the event type is set to `undefined`. So `emit('foo')` will cause a Typescript error.

This fixes it by removing the second argument if the event type is set to undefined.

---
common:
```ts
declare module '@nextcloud/event-bus' {
	export interface NextcloudEvents {
		// mapping of 'event name' => 'event type'
		'my:event': undefined
	}
}
```

before:
```ts
emit('my:event', undefined)
```

after
```ts
emit('my:event')
```