### PR TITLE
chore: prepare v3.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v3.3.2](https://github.com/nextcloud-libraries/nextcloud-event-bus/tree/v3.3.2) \(2025-02-28\)
+
+### Fixed
+
+- fix: Allow events without parameters [\#792](https://github.com/nextcloud-libraries/nextcloud-event-bus/pull/792) ([susnux](https://github.com/susnux)\)
+- fix: Resolve typos in doc strings [\#862](https://github.com/nextcloud-libraries/nextcloud-event-bus/pull/862) ([susnux](https://github.com/susnux)\)
+
+### Changed
+
+- Updated development dependencies
+- chore(deps): Bump semver to 7.6.3
+- Migrate REUSE to TOML format [\#801](https://github.com/nextcloud-libraries/nextcloud-event-bus/pull/801) ([AndyScherzinger](https://github.com/AndyScherzinger)\)
+- Update dependabot-approve-merge.yml from org [\#826](https://github.com/nextcloud-libraries/nextcloud-event-bus/pull/826) ([AndyScherzinger](https://github.com/AndyScherzinger)\)
+
 ## [v3.3.1](https://github.com/nextcloud-libraries/nextcloud-event-bus/tree/v3.3.1) \(2024-05-28\)
 
 ### Fixed
@@ -45,21 +59,21 @@ All notable changes to this project will be documented in this file.
 
 ### Dependencies
 
-- chore(deps-dev): Bump @rollup/plugin-replace from 5.0.2 to 5.0.3 by @dependabot
-- chore(deps-dev): Bump @rollup/plugin-typescript from 11.1.1 to 11.1.5 by @dependabot
-- chore(deps-dev): Bump @types/node from 20.3.3 to 20.4.1 by @dependabot
-- chore(deps-dev): Bump @types/semver from 7.5.0 to 7.5.3 by @dependabot
-- chore(deps-dev): Bump jest from 29.5.0 to 29.7.0 by @dependabot
-- chore(deps-dev): Bump jest-environment-jsdom from 29.5.0 to 29.7.0 by @dependabot
-- chore(deps-dev): Bump rollup from 2.79.1 to 4.0.2 by @dependabot
-- chore(deps-dev): Bump semver from 7.5.3 to 7.5.4 by @dependabot
-- chore(deps-dev): Bump tslib from 2.5.0 to 2.6.2 by @dependabot
-- chore(deps-dev): Bump typedoc from 0.24.7 to 0.25.2 by @dependabot
-- chore(deps-dev): Bump typescript from 5.0.4 to 5.2.2 by @dependabot
-- chore(deps-dev): Bump word-wrap from 1.2.3 to 1.2.4 by @dependabot
-- chore(deps): Bump @types/node from 20.1.7 to 20.8.6 by @dependabot
-- chore(deps): Bump semver from 7.5.1 to 7.5.3 by @dependabot
-- chore(deps): Bump tough-cookie from 4.1.2 to 4.1.3 by @dependabot
+- chore(deps-dev): Bump @rollup/plugin-replace to 5.0.3
+- chore(deps-dev): Bump @rollup/plugin-typescript to 11.1.5
+- chore(deps-dev): Bump @types/node to 20.4.1
+- chore(deps-dev): Bump @types/semver to 7.5.3
+- chore(deps-dev): Bump jest to 29.7.0
+- chore(deps-dev): Bump jest-environment-jsdom to 29.7.0
+- chore(deps-dev): Bump rollup to 4.0.2
+- chore(deps-dev): Bump semver to 7.5.4
+- chore(deps-dev): Bump tslib to 2.6.2
+- chore(deps-dev): Bump typedoc to 0.25.2
+- chore(deps-dev): Bump typescript to 5.2.2
+- chore(deps-dev): Bump word-wrap to 1.2.4
+- chore(deps): Bump @types/node to 20.8.6
+- chore(deps): Bump semver to 7.5.3
+- chore(deps): Bump tough-cookie to 4.1.3
 
 ## [v3.1.0](https://github.com/nextcloud/nextcloud-event-bus/tree/v3.1.0) (2023-05-17)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/event-bus",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/event-bus",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@types/semver": "^7.5.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/event-bus",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "A simple event bus to communicate between Nextcloud components.",
   "keywords": [
     "nextcloud"


### PR DESCRIPTION
## [v3.3.2](https://github.com/nextcloud-libraries/nextcloud-event-bus/tree/v3.3.2) \(2025-02-28\)

### Fixed
* fix: Allow events without parameters [\#792](https://github.com/nextcloud-libraries/nextcloud-event-bus/pull/792) ([susnux](https://github.com/susnux)\)
* fix: Resolve typos in doc strings [\#862](https://github.com/nextcloud-libraries/nextcloud-event-bus/pull/862) ([susnux](https://github.com/susnux)\)

### Changed
* Updated development dependencies
* chore(deps): Bump semver to 7.6.3
* Migrate REUSE to TOML format [\#801](https://github.com/nextcloud-libraries/nextcloud-event-bus/pull/801) ([AndyScherzinger](https://github.com/AndyScherzinger)\)
* Update dependabot-approve-merge.yml from org [\#826](https://github.com/nextcloud-libraries/nextcloud-event-bus/pull/826) ([AndyScherzinger](https://github.com/AndyScherzinger)\)