### PR TITLE
chore: update node version to include LTS and active

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,7 @@
         "vitest": "^3.0.7"
       },
       "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
+        "node": "^20 || ^22 || ^24"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,18 @@
     "vitest": "^3.0.7"
   },
   "engines": {
-    "node": "^20.0.0",
-    "npm": "^10.0.0"
+    "node": "^20 || ^22 || ^24"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "onFail": "warn",
+      "version": "^10.0.0"
+    },
+    "runtime": {
+      "name": "node",
+      "onFail": "warn",
+      "version": "^22.0.0"
+    }
   }
 }


### PR DESCRIPTION
As per https://github.com/nextcloud/standards/issues/5 apps should support Node 22 now (since October).
But as a library we also need to support 1 year older apps (for the 1yr maintenance e.g. groupware),
so we need to support Node 22 and 20.

Also as we do not have any node dependencies but this is a browser library we already can support the upcoming LTS 24 (current node).